### PR TITLE
change default mavlink port

### DIFF
--- a/osd/mavlink_parser.c
+++ b/osd/mavlink_parser.c
@@ -17,7 +17,7 @@
 #include "util.h"
 #include "mavlink/common/mavlink.h"
 
-#define MAVLINK_PORT  14550
+#define MAVLINK_PORT  14750
 
 extern Queue queue;
 


### PR DESCRIPTION
change default mavlink port to 14750. 14550 for external gs software